### PR TITLE
Adjust relationships type

### DIFF
--- a/src/types/TerraformCloudData.ts
+++ b/src/types/TerraformCloudData.ts
@@ -16,7 +16,7 @@ export type Relationship = {
 
 export type TerraformCloudData<Attributes> = Data & {
   attributes: Attributes
-  relationships?: [Relationship]
+  relationships?: Record<string, Relationship>
   links?: Links
 }
 


### PR DESCRIPTION
The API returns an object with a verb as key and the relationship as value (I checked runs and workspaces)