### PR TITLE
feat: retrieve all workspaces

### DIFF
--- a/src/api/endpoints/Workspaces.ts
+++ b/src/api/endpoints/Workspaces.ts
@@ -12,6 +12,11 @@ export default class Workspaces extends Request {
     return this.get<Workspace>(path)
   }
 
+  showAll(organizationName: string): Promise<Workspace[]> {
+    const path = `/organizations/${organizationName}/workspaces`
+    return this.get<Workspace[]>(path)
+  }
+
   show(workspaceId: string): Promise<Workspace> {
     const path = `/workspaces/${workspaceId}`
     return this.get<Workspace>(path)

--- a/src/types/Workspace.ts
+++ b/src/types/Workspace.ts
@@ -46,6 +46,7 @@ export interface WorkspaceAttributes {
   vcsRepo: null
   workingDirectory: string
   executionMode: 'remote' | 'local' | 'agent'
+  tagNames: string[]
 }
 
 export interface WorkspacePermissions {

--- a/test/mocks/WorkspaceMock.ts
+++ b/test/mocks/WorkspaceMock.ts
@@ -35,6 +35,7 @@ export const WorkspaceMock = {
       'vcs-repo': null,
       'working-directory': '',
       'execution-mode': 'agent',
+      tagNames: [],
     },
     relationships: {
       organization: {


### PR DESCRIPTION
This is a small PR to allow for a /organization/:id/workspaces call, retrieving all workspaces for an organization. This also adds tagNames to the WorkspaceAttributes interface.

Not sure how contributions work in this repo, please feel free to send me back to do more work.

I noticed that the tests for Workspaces are mocked, and none of the get requests have tests, so I did not add one for consistency.