### PR TITLE
feat: allow to upload more than 10 MB to TFC

### DIFF
--- a/src/api/endpoints/ConfigurationVersion.ts
+++ b/src/api/endpoints/ConfigurationVersion.ts
@@ -22,6 +22,6 @@ export default class ConfigurationVersions extends Request {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   async upload(url: string, data: any): Promise<any> {
-    return await axios.put(url, data)
+    return await axios.put(url, data, { maxBodyLength: 500 * 1000000 }) // 500MB
   }
 }


### PR DESCRIPTION
happens quickly when using lambda (which allows up to
50 MB without a separate S3 object and even more when using S3)
